### PR TITLE
Deploy should wait for successful tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,15 @@
 name: Deploy to Slack Cloud
 
 on:
-  push:
-    branches: [ main ]
+  workflow_run:
+    workflows: ["Deno app build and testing"]
+    types:
+      - completed
 
 jobs:
   deploy:
+    # Only run the deployment when merging to main AND tests have run successfully
+    if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Current implementation has both the test and the deployment workflows run at the same time. We don't want to deploy if the tests fail, so deploy should be dependent on the testing workflow.