### PR TITLE
add function to fetch future meetings

### DIFF
--- a/datastores/meeting_datastore.ts
+++ b/datastores/meeting_datastore.ts
@@ -1,7 +1,12 @@
 import { DefineDatastore, Schema } from "deno-slack-sdk/mod.ts";
+import { SlackAPIClient } from "deno-slack-sdk/types.ts";
+import { DatastoreItem } from "deno-slack-api/types.ts";
+import { DatastoreQueryResponse } from "deno-slack-api/typed-method-types/apps.ts";
+
+export const MEETING_DATASTORE = "Meeting";
 
 export const MeetingDatastore = DefineDatastore({
-  name: "Meeting",
+  name: MEETING_DATASTORE,
   primary_key: "id",
   attributes: {
     id: {
@@ -33,3 +38,44 @@ export const MeetingDatastore = DefineDatastore({
     },
   },
 });
+
+/**
+ * Returns the complete collection from the datastore for an expression
+ *
+ * @param client the client to interact with the Slack API
+ * @param expressions optional DynamoDB filters and attributes to refine a query ()
+ *
+ * @returns ok if the query completed successfully
+ * @returns items a list of responses from the datastore
+ * @returns error the description of any server error
+ */
+export async function queryMeetingDatastore(
+  client: SlackAPIClient,
+  expressions?: object,
+): Promise<{
+  ok: boolean;
+  items: DatastoreItem<typeof MeetingDatastore.definition>[];
+  error?: string;
+}> {
+  const items: DatastoreItem<typeof MeetingDatastore.definition>[] = [];
+  let cursor = undefined;
+
+  // Page through the database and collect all meetings that match filter expressions
+  do {
+    const meetings: DatastoreQueryResponse<typeof MeetingDatastore.definition> =
+      await client.apps.datastore.query<typeof MeetingDatastore.definition>({
+        datastore: MEETING_DATASTORE,
+        cursor,
+        ...expressions,
+      });
+
+    if (!meetings.ok) {
+      return { ok: false, items, error: meetings.error };
+    }
+
+    cursor = meetings.response_metadata?.next_cursor;
+    items.push(...meetings.items);
+  } while (cursor);
+
+  return { ok: true, items };
+}

--- a/functions/fetch_future_meetings.ts
+++ b/functions/fetch_future_meetings.ts
@@ -1,0 +1,64 @@
+import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { queryMeetingDatastore } from "../datastores/meeting_datastore.ts";
+import { MeetingInfoType } from "../types/meeting_info.ts";
+
+export const FetchFutureMeetingsFunction = DefineFunction({
+  callback_id: "fetch_future_meetings_function",
+  title: "Fetch Future Meetings",
+  description: "Fetch meetings that have not yet occurred",
+  source_file: "functions/fetch_future_meetings.ts",
+  input_parameters: {
+    properties: {},
+    required: [],
+  },
+  output_parameters: {
+    properties: {
+      meetings: {
+        type: Schema.types.array,
+        items: { type: MeetingInfoType },
+        title: "Meetings",
+        description: "Meetings that are set for the future",
+      },
+    },
+    required: ["meetings"],
+  },
+});
+
+export default SlackFunction(
+  FetchFutureMeetingsFunction,
+  async ({ client }) => {
+    const nowTimestampSeconds = Math.floor(new Date().getTime() / 1000);
+
+    // DynamoDB expression to represent "Timestamp in future"
+    const expressions = {
+      expression: "#timestamp > :nowTimestampSeconds", // Logic to query future meetings
+      expression_attributes: { "#timestamp": "timestamp" }, // Map query to timestamp field on Meeting record
+      expression_values: {
+        ":nowTimestampSeconds": nowTimestampSeconds,
+      }, // Map query to current time
+    };
+
+    const meetings = await queryMeetingDatastore(client, expressions);
+
+    if (!meetings.ok) {
+      return {
+        total: 0,
+        error: `Failed to fetch future meetings: ${meetings.error}`,
+      };
+    }
+
+    // Transform DB records to simplified MeetingInfo
+    const meetingInfo = meetings.items.map((meeting) => {
+      return {
+        id: meeting.id,
+        channel: meeting.channel,
+        timestamp: meeting.timestamp,
+      };
+    });
+
+    // Until we have tests and use this function in a workflow
+    console.log("The meeting info:", meetingInfo);
+
+    return { outputs: { meetings: meetingInfo } };
+  },
+);

--- a/manifest.ts
+++ b/manifest.ts
@@ -11,6 +11,7 @@ import { MeetingDatastore } from "./datastores/meeting_datastore.ts";
 import { CreateMeeting } from "./workflows/create_meeting.ts";
 import { CreateAgenda } from "./workflows/create_agenda.ts";
 import { CreatePoll } from "./workflows/create_poll.ts";
+import { MeetingInfoType } from "./types/meeting_info.ts";
 
 /**
  * The app manifest contains the app's configuration. This
@@ -40,6 +41,11 @@ export default Manifest({
     AgendaDatastore,
     RemindersDatastore,
     MeetingDatastore,
+  ],
+
+  // A list of custom Types the app will use
+  types: [
+    MeetingInfoType,
   ],
 
   /**

--- a/types/meeting_info.ts
+++ b/types/meeting_info.ts
@@ -1,0 +1,20 @@
+import { DefineType, Schema } from "deno-slack-sdk/mod.ts";
+
+export const MeetingInfoType = DefineType({
+  title: "Meeting Info",
+  description: "Represents a planned meeting location and time",
+  name: "meeting",
+  type: Schema.types.object,
+  properties: {
+    id: {
+      type: Schema.types.string,
+    },
+    channel: {
+      type: Schema.slack.types.channel_id,
+    },
+    timestamp: {
+      type: Schema.slack.types.timestamp,
+    },
+  },
+  required: ["id", "channel", "timestamp"],
+});


### PR DESCRIPTION
Builds off of the createMeeting functionality, adds the ability to fetch future meetings. This establishes a pattern we can follow for database fetching. This function can be used in one of the other workflows to offer users a list of meetings they want to set an agenda or reminder for. 