### PR TITLE
send reminder at set time

### DIFF
--- a/functions/create_reminder.ts
+++ b/functions/create_reminder.ts
@@ -1,7 +1,6 @@
 import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
 import { RemindersDatastore } from "../datastores/reminders.ts";
 import { SlackAPIClient } from "deno-slack-sdk/types.ts";
-import { SendReminder } from "../workflows/send_reminder.ts";
 import { CreateReminder } from "../workflows/create_reminder.ts";
 
 export const CreateReminderSetupFunction = DefineFunction({
@@ -51,15 +50,44 @@ export default SlackFunction(
       return { error: `Failed to create reminder: ${putResponse.error}` };
     }
 
-    // Search for any existing triggers for the welcome workflow
-    const triggers = await findMeetingReminderTrigger(client, channel);
-    if (triggers.error) {
-      return { error: `Failed to lookup existing triggers: ${triggers.error}` };
+    const setupResponse = await setupMeetingReminder(
+      client,
+      channel,
+      date,
+      message,
+    );
+    if (setupResponse.error) {
+      return { error: `Failed to setup reminder: ${setupResponse.error}` };
     }
+    // Search for any existing triggers for the welcome workflow
+    // const triggers = await findMeetingReminderTrigger(client, channel);
+    // if (triggers.error) {
+    //   return { error: `Failed to lookup existing triggers: ${triggers.error}` };
+    // }
 
     return { outputs: {} };
   },
 );
+
+export function setupMeetingReminder(
+  client: SlackAPIClient,
+  channel: string,
+  date: number,
+  message: string,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const result = client.chat.scheduleMessage({
+      channel: channel,
+      text: message,
+      post_at: date.toString(),
+    });
+    console.log(result);
+    return Promise.resolve({ ok: true });
+  } catch (error) {
+    console.error(error);
+    return Promise.resolve({ ok: false, error: error.message });
+  }
+}
 
 export async function findMeetingReminderTrigger(
   client: SlackAPIClient,
@@ -78,36 +106,4 @@ export async function findMeetingReminderTrigger(
   // Return if any matching triggers were found
   const exists = joinedTriggers.length > 0;
   return { exists };
-}
-
-/**
- * sendReminderChannelTrigger
- *  creates a new event trigger
- * for the "Send Reminder" workflow in a channel.
- */
-export async function sendReminderChannelTrigger(
-  client: SlackAPIClient,
-  channel: string,
-): Promise<{ ok: boolean; error?: string }> {
-  const triggerResponse = await client.workflows.triggers.create<
-    typeof SendReminder.definition
-  >({
-    type: "event",
-    name: "meeting reminder",
-    description: "Send a message when meeting reminder is set",
-    workflow: `#/workflows/${SendReminder.definition.callback_id}`,
-    event: {
-      event_type: "slack#/events/channel_renamed",
-      channel_ids: [channel],
-    },
-    inputs: {
-      channel: { value: channel },
-      triggered_user: { value: "{{data.user_id}}" },
-    },
-  });
-
-  if (!triggerResponse.ok) {
-    return { ok: false, error: triggerResponse.error };
-  }
-  return { ok: true };
 }


### PR DESCRIPTION
here is the fix for my previous PR
I found a fix here - https://api.slack.com/tutorials/tracks/scheduling-messages
where you can post a scheduled message
I think previously I was trying to force use triggers, which was not the most efficient way 😅 

Now, when you put the message and time in the set reminder workflow, the message will be sent by convo-crafters at the set time 😄 