### PR TITLE
import local name from env

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,2 @@
+# Copy this file to one named ".env", then fill out your own information
+LOCAL_NAME="Your Bot Name Here"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 package
 .DS_Store
 .slack/apps.dev.json
+.env

--- a/manifest.ts
+++ b/manifest.ts
@@ -1,4 +1,5 @@
 import { Manifest } from "deno-slack-sdk/mod.ts";
+import { load } from "std/dotenv/mod.ts";
 
 // Datastores
 import SampleObjectDatastore from "./datastores/sample_datastore.ts";
@@ -18,6 +19,7 @@ import { CreatePoll } from "./workflows/create_poll.ts";
 // Types
 import { MeetingInfoType } from "./types/meeting_info.ts";
 
+const env = await load();
 /**
  * The app manifest contains the app's configuration. This
  * file defines attributes like app name and description.
@@ -25,7 +27,7 @@ import { MeetingInfoType } from "./types/meeting_info.ts";
  */
 export default Manifest({
   // This is the app's internal name.
-  name: "Convo-Crafter",
+  name: env.LOCAL_NAME || "Convo-Crafter",
 
   // App description the helps users decide whether to us it.
   description: "A Slack bot that facilitates meeting functions and flow",


### PR DESCRIPTION
To help reduce confusion when local testing, dynamically set the name of the app in the manifest. Each of us should delete apps.dev.json in the .slack directory and regenerate it with `slack run`