### PR TITLE
simplify meetings

### DIFF
--- a/datastores/meeting_datastore.ts
+++ b/datastores/meeting_datastore.ts
@@ -12,24 +12,6 @@ export const MeetingDatastore = DefineDatastore({
     id: {
       type: Schema.types.string,
     },
-    reminders: {
-      type: Schema.types.array,
-      items: {
-        type: Schema.types.string,
-      },
-    },
-    agendas: {
-      type: Schema.types.array,
-      items: {
-        type: Schema.types.string,
-      },
-    },
-    action_items: {
-      type: Schema.types.array,
-      items: {
-        type: Schema.types.string,
-      },
-    },
     channel: {
       type: Schema.slack.types.channel_id,
     },


### PR DESCRIPTION
We don't need to store agendas, reminders and action items on the meeting entity. We can fetch those by meeting id.