### PR TITLE
update create agenda flow

### DIFF
--- a/datastores/meeting_datastore.ts
+++ b/datastores/meeting_datastore.ts
@@ -18,6 +18,9 @@ export const MeetingDatastore = DefineDatastore({
     timestamp: {
       type: Schema.slack.types.timestamp,
     },
+    name: {
+      type: Schema.types.string,
+    },
   },
 });
 

--- a/functions/channel_id_from_meeting.ts
+++ b/functions/channel_id_from_meeting.ts
@@ -1,0 +1,46 @@
+import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { MeetingInfo } from "../types/meeting_info.ts";
+
+// Note: I ended up not using this, but I think it will be useful when starting a meeting is added.
+export const ChannelIdFromMeetingFunction = DefineFunction({
+  callback_id: "channel_id_from_meeting",
+  title: "Get Channel ID from Meeting",
+  description:
+    "Given a meeting.id and a list meetings, get the channel id of the meeting.",
+  source_file: "functions/channel_id_from_meeting.ts",
+  input_parameters: {
+    properties: {
+      meeting_id: {
+        type: Schema.types.string,
+        description: "Selected meeting Id.",
+      },
+      meetings: {
+        type: Schema.types.array,
+        items: MeetingInfo,
+        description: "List of pre-fetched meetings",
+      },
+    },
+    required: ["meeting_id", "meetings"],
+  },
+  output_parameters: {
+    properties: {
+      channel_id: {
+        type: Schema.types.string,
+      },
+    },
+    required: ["channel_id"],
+  },
+});
+
+export default SlackFunction(
+  ChannelIdFromMeetingFunction,
+  ({ inputs }) => {
+    const { meeting_id, meetings } = inputs;
+
+    const selectedMeeting = meetings.find((meeting) =>
+      meeting.id === meeting_id
+    );
+
+    return { outputs: { channel_id: selectedMeeting.channel_id } };
+  },
+);

--- a/functions/create_meeting.ts
+++ b/functions/create_meeting.ts
@@ -16,6 +16,10 @@ export const CreateMeetingSetupFunction = DefineFunction({
         type: Schema.slack.types.timestamp,
         description: "Date to send the meeting",
       },
+      name: {
+        type: Schema.types.string,
+        description: "Name for the meeting",
+      },
     },
     required: ["channel", "timestamp"],
   },
@@ -24,7 +28,7 @@ export const CreateMeetingSetupFunction = DefineFunction({
 export default SlackFunction(
   CreateMeetingSetupFunction,
   async ({ inputs, client }) => {
-    const { channel, timestamp } = inputs;
+    const { channel, timestamp, name } = inputs;
     const uuid = crypto.randomUUID();
 
     // Save information about the welcome message to the datastore
@@ -32,7 +36,7 @@ export default SlackFunction(
       typeof MeetingDatastore.definition
     >({
       datastore: MeetingDatastore.name,
-      item: { id: uuid, channel, timestamp },
+      item: { id: uuid, channel, timestamp, name },
     });
 
     if (!putResponse.ok) {

--- a/functions/fetch_future_meetings.ts
+++ b/functions/fetch_future_meetings.ts
@@ -1,6 +1,7 @@
 import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
 import { queryMeetingDatastore } from "../datastores/meeting_datastore.ts";
-import { MeetingEnumChoice } from "../types/meeting_info.ts";
+import { EnumChoice } from "../types/enum_choice.ts";
+import { MeetingInfo } from "../types/meeting_info.ts";
 
 export const FetchFutureMeetingsFunction = DefineFunction({
   callback_id: "fetch_future_meetings_function",
@@ -21,11 +22,13 @@ export const FetchFutureMeetingsFunction = DefineFunction({
         type: Schema.types.array,
         items: { type: Schema.types.string },
       },
+      meeting_enum_choices: {
+        type: Schema.types.array,
+        items: { type: EnumChoice },
+      },
       meetings: {
         type: Schema.types.array,
-        items: { type: MeetingEnumChoice },
-        title: "Meetings",
-        description: "Meetings that are set for the future",
+        items: { type: MeetingInfo },
       },
       interactivity: {
         type: Schema.slack.types.interactivity,
@@ -49,30 +52,39 @@ export default SlackFunction(
       }, // Map query to current time
     };
 
-    const meetings = await queryMeetingDatastore(client, expressions);
+    const response = await queryMeetingDatastore(client, expressions);
 
-    if (!meetings.ok) {
+    if (!response.ok) {
       return {
         total: 0,
-        error: `Failed to fetch future meetings: ${meetings.error}`,
+        error: `Failed to fetch future meetings: ${response.error}`,
       };
     }
 
-    // Transform DB records to simplified MeetingInfo
-    const meetingInfo = meetings.items.map((meeting) => {
+    // Transform into different usable outputs
+    const meetings = response.items.map((meeting) => {
       return {
-        value: meeting.id,
-        // Temporary title, we should add a title to create meeting flow.
-        title: `Meeting at ${meeting.timestamp} in ${meeting.channel}`,
+        id: meeting.id,
+        name: meeting.name,
+        channel: meeting.channel,
+        timestamp: meeting.timestamp,
       };
     });
 
-    const meeting_ids = meetings.items.map((meeting) => meeting.id);
+    const meeting_enum_choices = response.items.map((meeting) => {
+      return {
+        value: meeting.id,
+        title: meeting.name,
+      };
+    });
+
+    const meeting_ids = response.items.map((meeting) => meeting.id);
 
     return {
       outputs: {
+        meetings,
+        meeting_enum_choices,
         meeting_ids,
-        meetings: meetingInfo,
         interactivity: inputs.interactivity,
       },
     };

--- a/functions/fetch_future_meetings.ts
+++ b/functions/fetch_future_meetings.ts
@@ -61,8 +61,12 @@ export default SlackFunction(
       };
     }
 
+    const sortedMeetings = response.items.toSorted((a, b) =>
+      a.timestamp - b.timestamp
+    );
+
     // Transform into different usable outputs
-    const meetings = response.items.map((meeting) => {
+    const meetings = sortedMeetings.map((meeting) => {
       return {
         id: meeting.id,
         name: meeting.name,
@@ -71,14 +75,16 @@ export default SlackFunction(
       };
     });
 
-    const meeting_enum_choices = response.items.map((meeting) => {
+    const meeting_enum_choices = sortedMeetings.map((meeting) => {
       return {
         value: meeting.id,
-        title: meeting.name,
+        title: `${meeting.name} at ${
+          // Timestamp is in seconds and Date needs ms
+          new Date(meeting.timestamp * 1000).toLocaleString()}`,
       };
     });
 
-    const meeting_ids = response.items.map((meeting) => meeting.id);
+    const meeting_ids = sortedMeetings.map((meeting) => meeting.id);
 
     return {
       outputs: {

--- a/manifest.ts
+++ b/manifest.ts
@@ -16,7 +16,8 @@ import { CreateAgendaItem } from "./workflows/create_agenda_item.ts";
 import { CreatePoll } from "./workflows/create_poll.ts";
 
 // Types
-import { MeetingEnumChoice } from "./types/meeting_info.ts";
+import { EnumChoice } from "./types/enum_choice.ts";
+import { MeetingInfo } from "./types/meeting_info.ts";
 
 const env = await load();
 /**
@@ -57,7 +58,8 @@ export default Manifest({
 
   // A list of custom Types the app will use
   types: [
-    MeetingEnumChoice,
+    EnumChoice,
+    MeetingInfo,
   ],
 
   /**

--- a/test/create_meeting_test.ts
+++ b/test/create_meeting_test.ts
@@ -19,6 +19,7 @@ type ExpectedItemType = {
   id?: string;
   channel?: string;
   timestamp?: number;
+  name?: string;
 };
 
 Deno.test("Successfully save a meeting", async () => {
@@ -40,6 +41,7 @@ Deno.test("Successfully save a meeting", async () => {
   const inputs = {
     channel: "channel-id",
     timestamp: 1710804,
+    name: "meeting name",
   };
 
   const { error, outputs } = await CreateMeetingFunction(
@@ -56,6 +58,7 @@ Deno.test("Successfully save a meeting", async () => {
   assertMatch(putItem.id, RegExp(/.+/)); // At least one character
   assertEquals(putItem.channel, "channel-id");
   assertEquals(putItem.timestamp, 1710804);
+  assertEquals(putItem.name, "meeting name");
 });
 
 Deno.test("Fail to save a meeting", async () => {
@@ -68,6 +71,7 @@ Deno.test("Fail to save a meeting", async () => {
   const inputs = {
     channel: "channel-id",
     timestamp: 1710804,
+    name: "meeting name",
   };
 
   const { error, outputs } = await CreateMeetingFunction(

--- a/test/fetch_future_meetings_test.ts
+++ b/test/fetch_future_meetings_test.ts
@@ -42,14 +42,30 @@ type ExpectedItemType = {
 
 Deno.test("Fetches only future meetings", async () => {
   mockMeetings = [
-    { id: "past-meeting-id", channel: "channel-id", timestamp: 1711000000 },
+    {
+      id: "past-meeting-id",
+      channel: "channel-id",
+      timestamp: 1711000000,
+      name: "past meeting",
+    },
     {
       id: "right-now-meeting-id",
       channel: "channel-id",
       timestamp: 1711000001,
+      name: "right now meeting",
     },
-    { id: "future-meeting-id-1", channel: "channel-id", timestamp: 1711000002 },
-    { id: "future-meeting-id-2", channel: "channel-id", timestamp: 1711000003 },
+    {
+      id: "future-meeting-id-1",
+      channel: "channel-id",
+      timestamp: 1711000002,
+      name: "future meeting 1",
+    },
+    {
+      id: "future-meeting-id-2",
+      channel: "channel-id",
+      timestamp: 1711000003,
+      name: "future meeting 2",
+    },
   ];
 
   const { error, outputs } = await FetchFutureMeetingsFunction(
@@ -63,14 +79,28 @@ Deno.test("Fetches only future meetings", async () => {
     outputs,
     {
       meeting_ids: ["future-meeting-id-1", "future-meeting-id-2"],
-      meetings: [
+      meeting_enum_choices: [
         {
           value: "future-meeting-id-1",
-          title: "Meeting at 1711000002 in channel-id",
+          title: "future meeting 1",
         },
         {
           value: "future-meeting-id-2",
-          title: "Meeting at 1711000003 in channel-id",
+          title: "future meeting 2",
+        },
+      ],
+      meetings: [
+        {
+          id: "future-meeting-id-1",
+          channel: "channel-id",
+          timestamp: 1711000002,
+          name: "future meeting 1",
+        },
+        {
+          id: "future-meeting-id-2",
+          channel: "channel-id",
+          timestamp: 1711000003,
+          name: "future meeting 2",
         },
       ],
       interactivity: undefined,

--- a/test/fetch_future_meetings_test.ts
+++ b/test/fetch_future_meetings_test.ts
@@ -57,13 +57,13 @@ Deno.test("Fetches only future meetings", async () => {
     {
       id: "future-meeting-id-1",
       channel: "channel-id",
-      timestamp: 1711000002,
+      timestamp: 1711000003,
       name: "future meeting 1",
     },
     {
       id: "future-meeting-id-2",
       channel: "channel-id",
-      timestamp: 1711000003,
+      timestamp: 1711000002,
       name: "future meeting 2",
     },
   ];
@@ -78,29 +78,33 @@ Deno.test("Fetches only future meetings", async () => {
   assertEquals(
     outputs,
     {
-      meeting_ids: ["future-meeting-id-1", "future-meeting-id-2"],
+      meeting_ids: ["future-meeting-id-2", "future-meeting-id-1"],
       meeting_enum_choices: [
         {
-          value: "future-meeting-id-1",
-          title: "future meeting 1",
+          value: "future-meeting-id-2",
+          title: `future meeting 2 at ${
+            new Date(1711000002000).toLocaleString()
+          }`,
         },
         {
-          value: "future-meeting-id-2",
-          title: "future meeting 2",
+          value: "future-meeting-id-1",
+          title: `future meeting 1 at ${
+            new Date(1711000003000).toLocaleString()
+          }`,
         },
       ],
       meetings: [
         {
-          id: "future-meeting-id-1",
-          channel: "channel-id",
-          timestamp: 1711000002,
-          name: "future meeting 1",
-        },
-        {
           id: "future-meeting-id-2",
           channel: "channel-id",
-          timestamp: 1711000003,
+          timestamp: 1711000002,
           name: "future meeting 2",
+        },
+        {
+          id: "future-meeting-id-1",
+          channel: "channel-id",
+          timestamp: 1711000003,
+          name: "future meeting 1",
         },
       ],
       interactivity: undefined,

--- a/types/enum_choice.ts
+++ b/types/enum_choice.ts
@@ -1,0 +1,17 @@
+import { DefineType, Schema } from "deno-slack-sdk/mod.ts";
+
+export const EnumChoice = DefineType({
+  title: "Enum Choice",
+  description: "Type representing one choice for an enum-based input.",
+  name: "enum_choice",
+  type: Schema.types.object,
+  properties: {
+    value: {
+      type: Schema.types.string,
+    },
+    title: {
+      type: Schema.types.string,
+    },
+  },
+  required: ["value", "title"],
+});

--- a/types/meeting_info.ts
+++ b/types/meeting_info.ts
@@ -1,17 +1,23 @@
 import { DefineType, Schema } from "deno-slack-sdk/mod.ts";
 
-export const MeetingEnumChoice = DefineType({
+export const MeetingInfo = DefineType({
   title: "Meeting Info",
-  description: "Represents a planned meeting location and time",
-  name: "meeting",
+  description: "Meeting information that mirrors datastore.",
+  name: "meeting_info",
   type: Schema.types.object,
   properties: {
-    value: {
+    id: {
       type: Schema.types.string,
     },
-    title: {
+    channel: {
+      type: Schema.slack.types.channel_id,
+    },
+    timestamp: {
+      type: Schema.slack.types.timestamp,
+    },
+    name: {
       type: Schema.types.string,
     },
   },
-  required: ["value", "title"],
+  required: ["id", "channel", "timestamp", "name"],
 });

--- a/workflows/create_agenda_item.ts
+++ b/workflows/create_agenda_item.ts
@@ -40,16 +40,16 @@ const SetupWorkflowForm = CreateAgendaItem.addStep(
           title: "Select a meeting",
           type: Schema.types.string,
           enum: futureMeetings.outputs.meeting_ids,
-          choices: futureMeetings.outputs.meetings,
+          choices: futureMeetings.outputs.meeting_enum_choices,
         },
         {
           name: "name",
-          title: "Provide the name of this agenda.",
+          title: "Provide the name of this agenda item.",
           type: Schema.types.string,
         },
         {
           name: "details",
-          title: "Provide details for this agenda.",
+          title: "Provide details for this agenda item.",
           type: Schema.types.string,
           long: true,
         },
@@ -70,15 +70,14 @@ CreateAgendaItem.addStep(CreateAgendaItemSetupFunction, {
 
 /**
  * This step uses the SendEphemeralMessage Slack function.
- * TODO: Make a custom function that takes in the selected meeting_id
- * and the fetched meetings and returns the channel_id.
- * With the channel_id, we can do the below ephemeral message.
+ * TODO: It doesn't make sense to send a message in the same channel as the meeting
+ * if the command is run from somewhere else. Might be worth having a generic confirmation
+ * dialog and use that instead of message based confirmation?
  */
 // CreateAgendaItem.addStep(Schema.slack.functions.SendEphemeralMessage, {
-//   channel_id: SetupWorkflowForm.outputs.fields.channel,
+//   channel_id: CreateAgendaItem.inputs.channel,
 //   user_id: CreateAgendaItem.inputs.interactivity.interactor.id,
-//   message:
-//     `Your meeting meeting for this channel was successfully created! :white_check_mark:`,
+//   message: `Your agenda item was successfully created! :white_check_mark:`,
 // });
 
 export default CreateAgendaItem;

--- a/workflows/create_meeting.ts
+++ b/workflows/create_meeting.ts
@@ -35,14 +35,14 @@ const SetupWorkflowForm = CreateMeeting.addStep(
           default: CreateMeeting.inputs.channel,
         },
         {
-          name: "date",
-          title: "Select a time to schedule the meeting",
-          type: Schema.slack.types.timestamp,
-        },
-        {
           name: "name",
           title: "Give a name to the meeting",
           type: Schema.types.string,
+        },
+        {
+          name: "date",
+          title: "Select a time to schedule the meeting",
+          type: Schema.slack.types.timestamp,
         },
       ],
     },

--- a/workflows/create_meeting.ts
+++ b/workflows/create_meeting.ts
@@ -26,7 +26,7 @@ const SetupWorkflowForm = CreateMeeting.addStep(
     description: ":wave: Create a meeting.",
     interactivity: CreateMeeting.inputs.interactivity,
     fields: {
-      required: ["channel", "date"],
+      required: ["channel", "date", "name"],
       elements: [
         {
           name: "channel",
@@ -36,8 +36,13 @@ const SetupWorkflowForm = CreateMeeting.addStep(
         },
         {
           name: "date",
-          title: "Select a time to send the meeting",
+          title: "Select a time to schedule the meeting",
           type: Schema.slack.types.timestamp,
+        },
+        {
+          name: "name",
+          title: "Give a name to the meeting",
+          type: Schema.types.string,
         },
       ],
     },
@@ -52,6 +57,7 @@ const SetupWorkflowForm = CreateMeeting.addStep(
 CreateMeeting.addStep(CreateMeetingSetupFunction, {
   channel: SetupWorkflowForm.outputs.fields.channel,
   timestamp: SetupWorkflowForm.outputs.fields.date,
+  name: SetupWorkflowForm.outputs.fields.name,
 });
 
 /**


### PR DESCRIPTION
Notes:
- It felt clunky to have the confirmation message sent to the meeting channel if the user is running the workflow from another channel. So not using the channel_id_from_meeting function
- EnumChoice type is naturally generic, so conceptually detached that from Meetings
- Use name and human readable timestamp for the enum choices