### PR TITLE
Prevent empty enum crash

### DIFF
--- a/functions/abort_on_empty_enum.ts
+++ b/functions/abort_on_empty_enum.ts
@@ -1,0 +1,55 @@
+import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { EnumChoice } from "../types/enum_choice.ts";
+import { DialogType, showDialog } from "./show_dialog.ts";
+
+export const AbortOnEmptyEnumFunction = DefineFunction({
+  callback_id: "abort_on_empty_enum",
+  title: "Abort on empty enum",
+  description: "Gracefully abort workflow if passed empty enum options.",
+  source_file: "functions/abort_on_empty_enum.ts",
+  input_parameters: {
+    properties: {
+      interactivity: {
+        type: Schema.slack.types.interactivity,
+      },
+      enum_choices: {
+        type: Schema.types.array,
+        items: { type: EnumChoice },
+        description: "List enum choices",
+      },
+      error_message: {
+        type: Schema.types.string,
+        description: "Message to show if enum is empty.",
+      },
+    },
+    required: ["enum_choices", "error_message", "interactivity"],
+  },
+  output_parameters: {
+    properties: {
+      interactivity: {
+        type: Schema.slack.types.interactivity,
+      },
+    },
+    required: [],
+  },
+});
+
+export default SlackFunction(
+  AbortOnEmptyEnumFunction,
+  async ({ inputs, client }) => {
+    const { enum_choices, interactivity, error_message } = inputs;
+
+    if (!enum_choices.length) {
+      await showDialog(
+        client,
+        error_message,
+        DialogType.Error,
+        interactivity?.interactivity_pointer,
+      );
+
+      return { error: `No enum options were provided.` };
+    } else {
+      return { outputs: { interactivity } };
+    }
+  },
+);

--- a/functions/create_agenda_item.ts
+++ b/functions/create_agenda_item.ts
@@ -20,15 +20,26 @@ export const CreateAgendaItemSetupFunction = DefineFunction({
         type: Schema.types.string,
         description: "Longer description of this agenda.",
       },
+      interactivity: {
+        type: Schema.slack.types.interactivity,
+      },
     },
-    required: ["meeting_id", "name", "details"],
+    required: ["meeting_id", "name", "details", "interactivity"],
+  },
+  output_parameters: {
+    properties: {
+      interactivity: {
+        type: Schema.slack.types.interactivity,
+      },
+    },
+    required: ["interactivity"],
   },
 });
 
 export default SlackFunction(
   CreateAgendaItemSetupFunction,
   async ({ inputs, client }) => {
-    const { meeting_id, name, details } = inputs;
+    const { meeting_id, name, details, interactivity } = inputs;
     const uuid = crypto.randomUUID();
 
     const putResponse = await client.apps.datastore.put<
@@ -42,6 +53,6 @@ export default SlackFunction(
       return { error: `Failed to create agenda item: ${putResponse.error}` };
     }
 
-    return { outputs: {} };
+    return { outputs: { interactivity } };
   },
 );

--- a/functions/fetch_future_meetings.ts
+++ b/functions/fetch_future_meetings.ts
@@ -34,7 +34,11 @@ export const FetchFutureMeetingsFunction = DefineFunction({
         type: Schema.slack.types.interactivity,
       },
     },
-    required: ["meetings"],
+    required: [
+      "meetings",
+      "meeting_enum_choices",
+      "meeting_ids",
+    ],
   },
 });
 

--- a/functions/show_dialog.ts
+++ b/functions/show_dialog.ts
@@ -1,0 +1,89 @@
+import { SlackAPIClient } from "deno-slack-sdk/deps.ts";
+import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+
+export enum DialogType {
+  Error = "error",
+  Success = "success",
+}
+
+export async function showDialog(
+  client: SlackAPIClient,
+  message: string,
+  dialogType: DialogType,
+  interactivityPointer: string,
+) {
+  const titleMapping = {
+    error: "Something Went Wrong!",
+    success: "Success!",
+  };
+  // Open a new modal with the end-user who interacted with the link trigger
+  await client.views.open({
+    interactivity_pointer: interactivityPointer,
+    view: {
+      type: "modal",
+      title: { type: "plain_text", text: titleMapping[dialogType] },
+      close: { type: "plain_text", text: "Close" },
+      blocks: [
+        {
+          type: "section",
+          text: { "type": "mrkdwn", "text": message },
+        },
+      ],
+    },
+  });
+}
+
+export const ShowDialogFunction = DefineFunction({
+  callback_id: "show_dialog",
+  title: "Show a dialog to the user",
+  description: "Shows a dialog to the user.",
+  source_file: "functions/show_dialog.ts",
+  input_parameters: {
+    properties: {
+      interactivity: {
+        type: Schema.slack.types.interactivity,
+      },
+      dialogType: {
+        type: Schema.types.string,
+        enum: ["success", "error"],
+        description: "Type of dialog to render",
+      },
+      message: {
+        type: Schema.types.string,
+        description: "Message to show in dialog.",
+      },
+    },
+    required: ["interactivity", "dialogType", "message"],
+  },
+  /**
+   * For some reason, having interactivity as an output parameter here
+   * causes parameter_validation_failed. In most cases,
+   * this is the last stop in the workflow, so we shouldn't
+   * need to output interactivity. We can just output {} until it
+   * is needed.
+   */
+  // output_parameters: {
+  //   properties: {
+  //     interactivity: {
+  //       type: Schema.slack.types.interactivity,
+  //     },
+  //   },
+  //   required: ["interactivity"],
+  // },
+});
+
+export default SlackFunction(
+  ShowDialogFunction,
+  async ({ inputs, client }) => {
+    const { interactivity, dialogType, message } = inputs;
+
+    await showDialog(
+      client,
+      message,
+      dialogType as DialogType,
+      interactivity.interactivity_pointer,
+    );
+
+    return { outputs: {} };
+  },
+);

--- a/workflows/create_agenda_item.ts
+++ b/workflows/create_agenda_item.ts
@@ -1,6 +1,8 @@
 import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
 import { CreateAgendaItemSetupFunction } from "../functions/create_agenda_item.ts";
 import { FetchFutureMeetingsFunction } from "../functions/fetch_future_meetings.ts";
+import { AbortOnEmptyEnumFunction } from "../functions/abort_on_empty_enum.ts";
+import { DialogType, ShowDialogFunction } from "../functions/show_dialog.ts";
 
 export const CreateAgendaItem = DefineWorkflow({
   callback_id: "create_agenda_item",
@@ -25,13 +27,23 @@ const futureMeetings = CreateAgendaItem.addStep(
   { interactivity: CreateAgendaItem.inputs.interactivity },
 );
 
+const enumCheck = CreateAgendaItem.addStep(
+  AbortOnEmptyEnumFunction,
+  {
+    enum_choices: futureMeetings.outputs.meeting_enum_choices,
+    interactivity: futureMeetings.outputs.interactivity,
+    error_message:
+      "No meetings were found. Please create a meeting before creating an agenda item.",
+  },
+);
+
 const SetupWorkflowForm = CreateAgendaItem.addStep(
   Schema.slack.functions.OpenForm,
   {
     title: "Create Agenda Item",
     submit_label: "Submit",
     description: ":wave: Add an agenda item.",
-    interactivity: futureMeetings.outputs.interactivity,
+    interactivity: enumCheck.outputs.interactivity,
     fields: {
       required: ["meeting", "name"],
       elements: [
@@ -62,22 +74,23 @@ const SetupWorkflowForm = CreateAgendaItem.addStep(
  * This step takes the form output and passes it along to a custom
  * function which saves the Agenda Item.
  */
-CreateAgendaItem.addStep(CreateAgendaItemSetupFunction, {
-  meeting_id: SetupWorkflowForm.outputs.fields.meeting,
-  name: SetupWorkflowForm.outputs.fields.name,
-  details: SetupWorkflowForm.outputs.fields.details,
-});
+const SaveAgendaItemToDatastore = CreateAgendaItem.addStep(
+  CreateAgendaItemSetupFunction,
+  {
+    meeting_id: SetupWorkflowForm.outputs.fields.meeting,
+    name: SetupWorkflowForm.outputs.fields.name,
+    details: SetupWorkflowForm.outputs.fields.details,
+    interactivity: SetupWorkflowForm.outputs.interactivity,
+  },
+);
 
 /**
- * This step uses the SendEphemeralMessage Slack function.
- * TODO: It doesn't make sense to send a message in the same channel as the meeting
- * if the command is run from somewhere else. Might be worth having a generic confirmation
- * dialog and use that instead of message based confirmation?
+ * Open a confirmation dialog
  */
-// CreateAgendaItem.addStep(Schema.slack.functions.SendEphemeralMessage, {
-//   channel_id: CreateAgendaItem.inputs.channel,
-//   user_id: CreateAgendaItem.inputs.interactivity.interactor.id,
-//   message: `Your agenda item was successfully created! :white_check_mark:`,
-// });
+CreateAgendaItem.addStep(ShowDialogFunction, {
+  interactivity: SaveAgendaItemToDatastore.outputs.interactivity,
+  dialogType: DialogType.Success,
+  message: `Your agenda item was successfully created! :white_check_mark:`,
+});
 
 export default CreateAgendaItem;


### PR DESCRIPTION
Added a function to check if the enum choices are empty and returning an error if so. Also added a showDialog function that can be used from within any other function and as a standalone workflow step.