### PR TITLE
add tests for abort on empty enum

### DIFF
--- a/functions/abort_on_empty_enum.ts
+++ b/functions/abort_on_empty_enum.ts
@@ -1,6 +1,6 @@
 import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
 import { EnumChoice } from "../types/enum_choice.ts";
-import { DialogType, showDialog } from "./show_dialog.ts";
+import { dialogHelpers, DialogType } from "./show_dialog.ts";
 
 export const AbortOnEmptyEnumFunction = DefineFunction({
   callback_id: "abort_on_empty_enum",
@@ -40,7 +40,7 @@ export default SlackFunction(
     const { enum_choices, interactivity, error_message } = inputs;
 
     if (!enum_choices.length) {
-      await showDialog(
+      await dialogHelpers.showDialog(
         client,
         error_message,
         DialogType.Error,

--- a/functions/show_dialog.ts
+++ b/functions/show_dialog.ts
@@ -77,7 +77,7 @@ export default SlackFunction(
   async ({ inputs, client }) => {
     const { interactivity, dialogType, message } = inputs;
 
-    await showDialog(
+    await dialogHelpers.showDialog(
       client,
       message,
       dialogType as DialogType,
@@ -87,3 +87,5 @@ export default SlackFunction(
     return { outputs: {} };
   },
 );
+
+export const dialogHelpers = { showDialog };

--- a/test/abort_on_empty_enum_test.ts
+++ b/test/abort_on_empty_enum_test.ts
@@ -1,0 +1,59 @@
+import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import AbortOnEmptyEnumFunction from "../functions/abort_on_empty_enum.ts";
+import { assertEquals } from "std/assert/assert_equals.ts";
+import { dialogHelpers, DialogType } from "../functions/show_dialog.ts";
+import {
+  assertSpyCalls,
+  stub,
+} from "https://deno.land/std@0.221.0/testing/mock.ts";
+
+const { createContext } = SlackFunctionTester("abort_on_empty_enum");
+
+Deno.test("Empty enum choices", async () => {
+  const showDialogStub = stub(dialogHelpers, "showDialog");
+
+  const inputs = {
+    interactivity: {
+      interactivity_pointer: "ptr",
+      interactor: { id: "uid", secret: "secret" },
+    },
+    enum_choices: [] as { value: string; title: string }[],
+    error_message: "An error message!",
+  };
+
+  const { error, outputs } = await AbortOnEmptyEnumFunction(
+    createContext({ inputs }),
+  );
+
+  // unwraps the showDialog method on the dialogHelpers object
+  showDialogStub.restore();
+
+  assertEquals(outputs, undefined);
+  assertEquals(error, "No enum options were provided.");
+
+  // showDialog only called once and with the correct args
+  assertSpyCalls(showDialogStub, 1);
+  assertEquals(showDialogStub.calls[0].args.slice(1), [
+    "An error message!",
+    DialogType.Error,
+    inputs.interactivity.interactivity_pointer,
+  ]);
+});
+
+Deno.test("not empty enum choices", async () => {
+  const inputs = {
+    interactivity: {
+      interactivity_pointer: "ptr",
+      interactor: { id: "uid", secret: "secret" },
+    },
+    enum_choices: [{ value: "value", title: "title" }],
+    error_message: "An error message!",
+  };
+
+  const { error, outputs } = await AbortOnEmptyEnumFunction(
+    createContext({ inputs }),
+  );
+
+  assertEquals(outputs, { interactivity: inputs.interactivity });
+  assertEquals(error, undefined);
+});


### PR DESCRIPTION
Added tests for abort_on_enum_function. Had to add the showDialog function to an exported object to make stubbing easier. It's pretty easy to use once you figure it out :)