### PR TITLE
don't throw error when rate limiting

### DIFF
--- a/functions/show_dialog.ts
+++ b/functions/show_dialog.ts
@@ -4,6 +4,7 @@ import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
 export enum DialogType {
   Error = "error",
   Success = "success",
+  RateLimit = "ratelimit",
 }
 
 export async function showDialog(
@@ -15,6 +16,7 @@ export async function showDialog(
   const titleMapping = {
     error: "Something Went Wrong!",
     success: "Success!",
+    ratelimit: "Too Many Requests",
   };
   // Open a new modal with the end-user who interacted with the link trigger
   await client.views.open({

--- a/functions/topic_definition.ts
+++ b/functions/topic_definition.ts
@@ -27,6 +27,10 @@ export const SendRequestToSpeakerFunction = DefineFunction({
         type: Schema.types.string,
         description: "Your reason for wanting to move to the next topic",
       },
+      speaker_locked: {
+        type: Schema.types.boolean,
+        description: "Whether or not the speaker is locked to prevent spam.",
+      },
     },
     required: [
       "speaker",

--- a/workflows/next_topic.ts
+++ b/workflows/next_topic.ts
@@ -50,8 +50,6 @@ const formData = RequestNextTopic.addStep(
 const LockCheck = RequestNextTopic.addStep(CheckNextTopicLock, {
   interactivity: formData.outputs.interactivity,
   speaker_id: formData.outputs.fields.speaker,
-  error_message:
-    "The speaker has already received a request to move to the next topic. Please wait before sending another request.",
 });
 
 // Step 3: send next topic request details along with approve/deny buttons to speaker
@@ -60,6 +58,7 @@ RequestNextTopic.addStep(SendRequestToSpeakerFunction, {
   listener: RequestNextTopic.inputs.interactivity.interactor.id,
   speaker: formData.outputs.fields.speaker,
   reason: formData.outputs.fields.reason,
+  speaker_locked: LockCheck.outputs.result,
 });
 
 export default RequestNextTopic;


### PR DESCRIPTION
From feedback in https://github.com/stmcdonald-vt/convo-crafters/pull/39 (@silverge )

Don't error out when the lock check finds an active lock. Return the result of the check and pass to the next topic function.