### PR TITLE
add a check for user's timezone when displaying datetime

### DIFF
--- a/functions/fetch_future_meetings.ts
+++ b/functions/fetch_future_meetings.ts
@@ -13,6 +13,9 @@ export const FetchFutureMeetingsFunction = DefineFunction({
       interactivity: {
         type: Schema.slack.types.interactivity,
       },
+      timezone: {
+        type: Schema.types.string,
+      },
     },
     required: [],
   },
@@ -82,12 +85,19 @@ export default SlackFunction(
       };
     });
 
+    const localeOptions = inputs.timezone
+      ? { timeZone: inputs.timezone } as Intl.DateTimeFormatOptions
+      : undefined;
+
     const meeting_enum_choices = sortedMeetings.map((meeting) => {
       return {
         value: meeting.id,
         title: `${meeting.name} at ${
           // Timestamp is in seconds and Date needs ms
-          new Date(meeting.timestamp * 1000).toLocaleString()}`,
+          new Date(meeting.timestamp * 1000).toLocaleString(
+            "en-US",
+            localeOptions,
+          )}`,
       };
     });
 

--- a/functions/fetch_past_meetings.ts
+++ b/functions/fetch_past_meetings.ts
@@ -13,6 +13,9 @@ export const FetchPastMeetingsFunction = DefineFunction({
       interactivity: {
         type: Schema.slack.types.interactivity,
       },
+      timezone: {
+        type: Schema.types.string,
+      },
     },
     required: [],
   },
@@ -79,12 +82,19 @@ export default SlackFunction(
       };
     });
 
+    const localeOptions = inputs.timezone
+      ? { timeZone: inputs.timezone } as Intl.DateTimeFormatOptions
+      : undefined;
+
     const meeting_enum_choices = sortedMeetings.map((meeting) => {
       return {
         value: meeting.id,
         title: `${meeting.name} at ${
           // Timestamp is in seconds and Date needs ms
-          new Date(meeting.timestamp * 1000).toLocaleString()}`,
+          new Date(meeting.timestamp * 1000).toLocaleString(
+            "en-US",
+            localeOptions,
+          )}`,
       };
     });
 

--- a/functions/fetch_reminders_for_channel.ts
+++ b/functions/fetch_reminders_for_channel.ts
@@ -15,6 +15,9 @@ export const FetchRemindersForChannelFunction = DefineFunction({
       channel: {
         type: Schema.slack.types.channel_id,
       },
+      timezone: {
+        type: Schema.types.string,
+      },
     },
     required: ["channel"],
   },
@@ -71,12 +74,19 @@ export default SlackFunction(
       };
     });
 
+    const localeOptions = inputs.timezone
+      ? { timeZone: inputs.timezone } as Intl.DateTimeFormatOptions
+      : undefined;
+
     const reminder_enum_choices = reminders.map((reminder) => {
       return {
         value: reminder.id,
         title: `${reminder.message} at ${
           // Timestamp is in seconds and Date needs ms
-          new Date(reminder.date * 1000).toLocaleString()}`,
+          new Date(reminder.date * 1000).toLocaleString(
+            "en-US",
+            localeOptions,
+          )}`,
       };
     });
 

--- a/functions/get_user_timezone.ts
+++ b/functions/get_user_timezone.ts
@@ -1,0 +1,49 @@
+import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+
+export const GetUserTimezoneFunction = DefineFunction({
+  callback_id: "get_user_timezone",
+  title: "Get User Timezone",
+  description: "Gets the user's timezone",
+  source_file: "functions/get_user_timezone.ts",
+  input_parameters: {
+    properties: {
+      user: {
+        type: Schema.slack.types.user_id,
+        description: "User Id to check timezone for",
+      },
+      interactivity: {
+        type: Schema.slack.types.interactivity,
+      },
+    },
+    required: ["user"],
+  },
+  output_parameters: {
+    properties: {
+      timezone: {
+        type: Schema.types.string,
+        description: "User's timezone",
+      },
+      interactivity: {
+        type: Schema.slack.types.interactivity,
+      },
+    },
+    required: ["timezone"],
+  },
+});
+
+export default SlackFunction(
+  GetUserTimezoneFunction,
+  async ({ inputs, client }) => {
+    const { user, interactivity } = inputs;
+
+    const response = await client.users.info({ user, include_timezone: true });
+
+    if (!response.ok) {
+      return { error: `Unable to fetch user's information ${response.error}` };
+    }
+
+    const timezone = response.user.tz || "";
+
+    return { outputs: { timezone, interactivity } };
+  },
+);

--- a/functions/send_action_list.ts
+++ b/functions/send_action_list.ts
@@ -20,6 +20,9 @@ export const SendActionFunction = DefineFunction({
       user: {
         type: Schema.slack.types.user_id,
       },
+      timezone: {
+        type: Schema.types.string,
+      },
     },
     required: ["action_items", "channel", "user"],
   },
@@ -28,13 +31,18 @@ export const SendActionFunction = DefineFunction({
 export default SlackFunction(
   SendActionFunction,
   async ({ inputs, client }) => {
-    const { action_items, channel, user } = inputs;
+    const { action_items, channel, user, timezone } = inputs;
 
     let message = "";
     if (action_items.length) {
       message += "*User Action List:*\n";
       message += action_items.map((item) =>
-        actionItemToMarkdownBullet(item.name, item.end_date, item.details)
+        actionItemToMarkdownBullet(
+          item.name,
+          item.end_date,
+          item.details,
+          timezone,
+        )
       ).join("\n");
     } else {
       message += "This user does not have any action items.";
@@ -55,9 +63,17 @@ export default SlackFunction(
 function actionItemToMarkdownBullet(
   action: string,
   end_date: number,
+  timezone: string,
   details?: string,
 ) {
-  const readableDeadline = new Date(end_date * 1000).toLocaleString();
+  const localeOptions = timezone
+    ? { timeZone: timezone } as Intl.DateTimeFormatOptions
+    : undefined;
+
+  const readableDeadline = new Date(end_date * 1000).toLocaleString(
+    "en-US",
+    localeOptions,
+  );
   let actionItem = `• ${action} | due: ${readableDeadline}`;
   if (details) {
     actionItem += `\n    • ${details}`;

--- a/manifest.ts
+++ b/manifest.ts
@@ -101,5 +101,6 @@ export default Manifest({
     "triggers:read", // Read new Platform triggers
     "bookmarks:write",
     "channels:join",
+    "users:read", // Needed to get user's timezone
   ],
 });

--- a/workflows/check_user_action_list.ts
+++ b/workflows/check_user_action_list.ts
@@ -1,6 +1,7 @@
 import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
 import { FetchUserActionItemsFunction } from "../functions/fetch_action_item_by_user.ts";
 import { SendActionFunction } from "../functions/send_action_list.ts";
+import { GetUserTimezoneFunction } from "../functions/get_user_timezone.ts";
 
 export const CheckUserAction = DefineWorkflow({
   callback_id: "check_user_action_list",
@@ -19,12 +20,20 @@ export const CheckUserAction = DefineWorkflow({
   },
 });
 
+const timezoneCheck = CheckUserAction.addStep(
+  GetUserTimezoneFunction,
+  {
+    user: CheckUserAction.inputs.interactivity.interactor.id,
+    interactivity: CheckUserAction.inputs.interactivity,
+  },
+);
+
 const SetupWorkflowForm = CheckUserAction.addStep(
   Schema.slack.functions.OpenForm,
   {
     title: "Start a meeting",
     submit_label: "Submit",
-    interactivity: CheckUserAction.inputs.interactivity,
+    interactivity: timezoneCheck.outputs.interactivity,
     fields: {
       required: ["user"],
       elements: [

--- a/workflows/create_action_item.ts
+++ b/workflows/create_action_item.ts
@@ -2,6 +2,7 @@ import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
 import { CreateActionItemSetupFunction } from "../functions/create_action_item.ts";
 import { FetchPastMeetingsFunction } from "../functions/fetch_past_meetings.ts";
 import { AbortOnEmptyEnumFunction } from "../functions/abort_on_empty_enum.ts";
+import { GetUserTimezoneFunction } from "../functions/get_user_timezone.ts";
 
 export const CreateActionItem = DefineWorkflow({
   callback_id: "create_action_item",
@@ -20,10 +21,21 @@ export const CreateActionItem = DefineWorkflow({
   },
 });
 
+const timezoneCheck = CreateActionItem.addStep(
+  GetUserTimezoneFunction,
+  {
+    user: CreateActionItem.inputs.interactivity.interactor.id,
+    interactivity: CreateActionItem.inputs.interactivity,
+  },
+);
+
 // Gather past meetings and pass through interactivity
 const pastMeetings = CreateActionItem.addStep(
   FetchPastMeetingsFunction,
-  { interactivity: CreateActionItem.inputs.interactivity },
+  {
+    interactivity: timezoneCheck.outputs.interactivity,
+    timezone: timezoneCheck.outputs.timezone,
+  },
 );
 
 // Check if meetings exist or not

--- a/workflows/create_agenda_item.ts
+++ b/workflows/create_agenda_item.ts
@@ -3,6 +3,7 @@ import { CreateAgendaItemSetupFunction } from "../functions/create_agenda_item.t
 import { FetchFutureMeetingsFunction } from "../functions/fetch_future_meetings.ts";
 import { AbortOnEmptyEnumFunction } from "../functions/abort_on_empty_enum.ts";
 import { DialogType, ShowDialogFunction } from "../functions/show_dialog.ts";
+import { GetUserTimezoneFunction } from "../functions/get_user_timezone.ts";
 
 export const CreateAgendaItem = DefineWorkflow({
   callback_id: "create_agenda_item",
@@ -21,10 +22,21 @@ export const CreateAgendaItem = DefineWorkflow({
   },
 });
 
+const timezoneCheck = CreateAgendaItem.addStep(
+  GetUserTimezoneFunction,
+  {
+    user: CreateAgendaItem.inputs.interactivity.interactor.id,
+    interactivity: CreateAgendaItem.inputs.interactivity,
+  },
+);
+
 // Gather future meetings and pass through interactivity
 const futureMeetings = CreateAgendaItem.addStep(
   FetchFutureMeetingsFunction,
-  { interactivity: CreateAgendaItem.inputs.interactivity },
+  {
+    interactivity: timezoneCheck.outputs.interactivity,
+    timezone: timezoneCheck.outputs.timezone,
+  },
 );
 
 const enumCheck = CreateAgendaItem.addStep(

--- a/workflows/create_reminder.ts
+++ b/workflows/create_reminder.ts
@@ -1,6 +1,7 @@
 import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
 import { CreateReminderSetupFunction } from "../functions/create_reminder.ts";
 import { FetchFutureMeetingsFunction } from "../functions/fetch_future_meetings.ts";
+import { GetUserTimezoneFunction } from "../functions/get_user_timezone.ts";
 
 export const CreateReminder = DefineWorkflow({
   callback_id: "create_reminder",
@@ -19,10 +20,21 @@ export const CreateReminder = DefineWorkflow({
   },
 });
 
+const timezoneCheck = CreateReminder.addStep(
+  GetUserTimezoneFunction,
+  {
+    user: CreateReminder.inputs.interactivity.interactor.id,
+    interactivity: CreateReminder.inputs.interactivity,
+  },
+);
+
 // Gather future meetings and pass through interactivity
 const futureMeetings = CreateReminder.addStep(
   FetchFutureMeetingsFunction,
-  { interactivity: CreateReminder.inputs.interactivity },
+  {
+    interactivity: timezoneCheck.outputs.interactivity,
+    timezone: timezoneCheck.outputs.timezone,
+  },
 );
 
 const SetupWorkflowForm = CreateReminder.addStep(

--- a/workflows/start_meeting.ts
+++ b/workflows/start_meeting.ts
@@ -5,6 +5,8 @@ import { ChannelIdFromMeetingFunction } from "../functions/channel_id_from_meeti
 import { FetchMeetingAgendaItemsFunction } from "../functions/fetch_meeting_agenda_items.ts";
 import { SendAgendaFunction } from "../functions/send_agenda.ts";
 import { RequestActionItems } from "../functions/request_action_items.ts";
+import { GetUserTimezoneFunction } from "../functions/get_user_timezone.ts";
+
 export const StartMeeting = DefineWorkflow({
   callback_id: "start_meeting",
   title: "Start a Meeting",
@@ -22,10 +24,21 @@ export const StartMeeting = DefineWorkflow({
   },
 });
 
+const timezoneCheck = StartMeeting.addStep(
+  GetUserTimezoneFunction,
+  {
+    user: StartMeeting.inputs.interactivity.interactor.id,
+    interactivity: StartMeeting.inputs.interactivity,
+  },
+);
+
 // Gather future meetings and pass through interactivity
 const futureMeetings = StartMeeting.addStep(
   FetchFutureMeetingsFunction,
-  { interactivity: StartMeeting.inputs.interactivity },
+  {
+    interactivity: timezoneCheck.outputs.interactivity,
+    timezone: timezoneCheck.outputs.timezone,
+  },
 );
 
 const enumCheck = StartMeeting.addStep(


### PR DESCRIPTION
Add a function to get the user's timezone. Anywhere we're displaying datetime, fetch the timezone in the step before. This does slow down some of the workflows because it requires an additional fetch, but unfortunately, slack's interactivity doesn't include timezone.